### PR TITLE
Update github-pages.yml

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -10,7 +10,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3.0.0
       - name: build_and_deploy
-        uses: shalzz/zola-deploy-action@v0.20.0
+        uses: shalzz/zola-deploy-action@v0.18.0
         env:
           PAGES_BRANCH: gh-pages
           TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
actions が queued になったまま走らない。
zola deploy action のバージョンアップに起因するので、一旦バージョンを下げてみる。