### PR TITLE
fix: OGP画像URLの修正

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -37,7 +37,7 @@
 <meta property="og:description" content="{{ page.description }}">
 {% endif %}
 {% if page.extra.cover %}
-<meta property="og:image" content="{{ page.permalink }}{{ page.extra.cover }}">
+<meta property="og:image" content="{{ page.extra.cover }}">
 {% endif %}
 
 <meta name="twitter:card" content="summary_large_image">
@@ -48,7 +48,7 @@
 <meta name="twitter:description" content="{{ page.description }}">
 {% endif %}
 {% if page.extra.cover %}
-<meta name="twitter:image" content="{{ page.permalink }}{{ page.extra.cover }}">
+<meta name="twitter:image" content="{{ page.extra.cover }}">
 {% endif %}
 {% endblock head %}
 


### PR DESCRIPTION
## 概要
OGP画像とTwitter Card画像のURLから`{{ page.permalink }}`を削除し、`{{ page.extra.cover }}`のみを使用するように修正しました。

## 変更内容
- `templates/post.html` のOGP画像URLを `{{ page.extra.cover }}` のみに変更
- Twitter Card画像URLも同様に `{{ page.extra.cover }}` のみに変更

## 理由
coverパスが絶対パス（`/assets/cover.png`）で設定されているため、`page.permalink`との結合が不要です。

## 差分
```diff
-<meta property="og:image" content="{{ page.permalink }}{{ page.extra.cover }}">
+<meta property="og:image" content="{{ page.extra.cover }}">

-<meta name="twitter:image" content="{{ page.permalink }}{{ page.extra.cover }}">
+<meta name="twitter:image" content="{{ page.extra.cover }}">
```