### PR TITLE
fix: cover imageのパスを/assetsから始まる形式に統一

### DIFF
--- a/content/blog/2025-03-08-first-post.md
+++ b/content/blog/2025-03-08-first-post.md
@@ -20,7 +20,7 @@ display_tags = true
 truncate_summary = false
 featured = false
 reaction = false
-cover = "assets/cover.png"
+cover = "/assets/cover.png"
 +++
 
 先日風邪を引いてしまい、自宅で療養していたわけだが、あまりにもやることがなく暇だったので以前から作ろうと思っていた個人 Blog を作った。

--- a/content/blog/2025-03-16-consistent-hashing-in-rust.md
+++ b/content/blog/2025-03-16-consistent-hashing-in-rust.md
@@ -20,7 +20,7 @@ display_tags = true
 truncate_summary = false
 featured = false
 reaction = false
-cover = "assets/cover.png"
+cover = "/assets/cover.png"
 +++
 
 [大規模データセットのためのアルゴリズムとデータ構造](https://book.mynavi.jp/ec/products/detail/id=143918) という本を読んでいる。

--- a/content/blog/2025-06-12-oss-contribution.md
+++ b/content/blog/2025-06-12-oss-contribution.md
@@ -20,7 +20,7 @@ display_tags = true
 truncate_summary = false
 featured = false
 reaction = false
-cover = "assets/cover.png"
+cover = "/assets/cover.png"
 +++
 
 [以前のブログ](@/blog/2025-03-16-consistent-hashing-in-rust.md) で Rust を書いて以降、 Rust に興味を持ち始めました。

--- a/content/blog/2025-09-18-a-solitaire-mystery.md
+++ b/content/blog/2025-09-18-a-solitaire-mystery.md
@@ -20,7 +20,7 @@ display_tags = true
 truncate_summary = false
 featured = false
 reaction = false
-cover = "assets/cover.png"
+cover = "/assets/cover.png"
 +++
 
 時間ができたのでゲームでも嗜むかと思い、Steam を漁っていたところ、「baba is you」で有名な Hempuli 氏の新作ゲームが発売されているところを発見した。

--- a/content/blog/2025-10-11-homelab-k8s-mpi-operator.md
+++ b/content/blog/2025-10-11-homelab-k8s-mpi-operator.md
@@ -21,7 +21,7 @@ display_tags = true
 truncate_summary = false
 featured = false
 reaction = false
-cover = "assets/cover.png"
+cover = "/assets/cover.png"
 +++
 
 自宅で Kubernetes クラスタを運用していて、最近 [MPI Operator](https://github.com/kubeflow/mpi-operator) などのコンポーネントを ArgoCD で整備したのでまとめてみる。


### PR DESCRIPTION
## 概要

すべてのブログ記事のcover imageパスを相対パスから絶対パスに変更しました。

## 変更内容

- `cover = "assets/cover.png"` → `cover = "/assets/cover.png"`

以下の5つのブログ記事を更新:
- content/blog/2025-10-11-homelab-k8s-mpi-operator.md
- content/blog/2025-09-18-a-solitaire-mystery.md
- content/blog/2025-06-12-oss-contribution.md
- content/blog/2025-03-16-consistent-hashing-in-rust.md
- content/blog/2025-03-08-first-post.md

## 変更理由

相対パスでの指定だと、ページの階層によって画像パスが正しく解決されない可能性があります。
絶対パス (`/assets` から開始) にすることで、どの階層のページからでも正しくcover画像を参照できるようになります。