### PR TITLE
fix: OGP画像URLにbase_urlを追加

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -37,7 +37,7 @@
 <meta property="og:description" content="{{ page.description }}">
 {% endif %}
 {% if page.extra.cover %}
-<meta property="og:image" content="{{ page.extra.cover }}">
+<meta property="og:image" content="{{ config.base_url ~ page.extra.cover }}">
 {% endif %}
 
 <meta name="twitter:card" content="summary_large_image">
@@ -48,7 +48,7 @@
 <meta name="twitter:description" content="{{ page.description }}">
 {% endif %}
 {% if page.extra.cover %}
-<meta name="twitter:image" content="{{ page.extra.cover }}">
+<meta name="twitter:image" content="{{ config.base_url ~ page.extra.cover }}">
 {% endif %}
 {% endblock head %}
 


### PR DESCRIPTION
## Why

- SNSシェア時にOGP画像が正しく表示されない問題を解決するため
- 現状では相対パスのみが指定されており、完全なURLが生成されていないため

## What

- `templates/post.html`のOGP画像URLとTwitterカード画像URLに`config.base_url`を結合
  - `{{ page.extra.cover }}` → `{{ config.base_url ~ page.extra.cover }}`
- これにより完全なURL（`https://donkomura.github.io/assets/cover.png`）が生成される